### PR TITLE
Randomize new partner rather than run whole process

### DIFF
--- a/src/model/model.class.ts
+++ b/src/model/model.class.ts
@@ -283,11 +283,11 @@ export class Model {
       return this.mutatePermutation();
     }
 
-    const partner = min + 1 == max ? min : Paul.chooseBetween(max, min, BIAS.REVERSE_BELL);
-    if (chosen == partner) {
-      // would that ever happen ?
-      return this.mutatePermutation();
+    let partner = min + 1 == max ? min : Paul.chooseBetween(max, min, BIAS.REVERSE_BELL);
+    while (chosen == partner) {
+      partner = Paul.chooseBetween(max, min, BIAS.REVERSE_BELL);
     }
+
     const [a] = Model._order.splice(chosen, 1);
 
     const b = Model._order[partner];

--- a/src/model/model.class.ts
+++ b/src/model/model.class.ts
@@ -285,6 +285,9 @@ export class Model {
 
     let partner = min + 1 == max ? min : Paul.chooseBetween(max, min, BIAS.REVERSE_BELL);
     while (chosen == partner) {
+      // if chosen is same as partner
+      // randomize until it isn't
+      // this will work on condition: there are more than two choices in range.
       partner = Paul.chooseBetween(max, min, BIAS.REVERSE_BELL);
     }
 


### PR DESCRIPTION
Hi, I noticed this process is possibly slowing down compilation time.

### TLDR;
You can jump to [(3)](https://arc.net/l/quote/dhhqcsuc) for more clarification.

### Background
In the mutation of permutation, CryptOpt finds the range of independent operators. Each range is defined by minimum & maximum (min & max).

<img width="346" alt="range" src="https://github.com/0xADE1A1DE/CryptOpt/assets/71058159/4c293dfa-b24a-4947-b537-18f3cbdf4772">

Then, the Optimizer selects **chosen** and **partner** between [min, max] range for instruction scheduling. It results in three possibilities.

1. There is only one operator in the range (min == max). So, it must pick up another range by re-permutation.
<img width="335" alt="range1" src="https://github.com/0xADE1A1DE/CryptOpt/assets/71058159/9646fef3-7c52-4cff-95a2-1067de56a29f">

2. The operators in the range are only two operators (min + 1 == max). The optimizer can switch between min & max.
<img width="335" alt="range 2" src="https://github.com/0xADE1A1DE/CryptOpt/assets/71058159/439b57cf-31c4-41a3-9ecd-0ec66aebfe1b">

3. More than 2 choices in operators (max - min > 2). In case **chosen** and **partner** are **same** elements, the current program decides to run the whole permutation process. I think this will slow down the mutation time. 

**Solution:** Instead, we are able to **randomize** another potential **partner** in the **same range**.

<img width="335" alt="range 3" src="https://github.com/0xADE1A1DE/CryptOpt/assets/71058159/6e753fb4-6556-4cf1-8e40-9cf413a4ba96">







